### PR TITLE
Setting None should be the equivalent of deleting an attribute

### DIFF
--- a/rdfalchemy/descriptors.py
+++ b/rdfalchemy/descriptors.py
@@ -167,9 +167,12 @@ class rdfSingle(rdfAbstract):
         if isinstance(value, (list, tuple, set)):
             raise AttributeError(
                 "to set an rdfSingle you must pass in a single value")
-        obj.__dict__[self.name] = value
-        o = value2object(value)
-        obj.db.set((obj.resUri, self.pred, o))
+        if value is None:
+            self.__delete__(obj)
+        else:
+            obj.__dict__[self.name] = value
+            o = value2object(value)
+            obj.db.set((obj.resUri, self.pred, o))
 
 
 class rdfMultiple(rdfAbstract):
@@ -210,6 +213,9 @@ class rdfMultiple(rdfAbstract):
             raise AttributeError(
                 "to set a rdfMultiple you must pass in " +
                 "a list (it can be a list of one)")
+        if newvals is None:
+            self.__delete__(obj)
+            return
         try:
             oldvals = obj.__dict__[self.name]
         except KeyError:

--- a/test/company_test.py
+++ b/test/company_test.py
@@ -97,6 +97,16 @@ def test_3():
     assert not c.industry
 
 
+def test_set_none_value():
+    '''Setting None should be the equivalent of deleting an attribute.'''
+    c = Company.get_by(symbol='IBM')
+    assert c.companyName == "International Business Machines Corp."
+    c.companyName = None
+    assert c.companyName != "International Business Machines Corp."
+    c = Company.get_by(symbol='IBM')
+    assert not c.companyName
+
+
 def test_creating():
     c2 = Company(OV.A)
     c3 = Company('<http://owl.openvest.org/2005/10/Portfolio#A>')


### PR DESCRIPTION
Currently, setting a value as None results in a TypeError, when rdflib attempts to create a Literal from None. 