### PR TITLE
Prepared for RDFlib 5.0

### DIFF
--- a/rdfalchemy/rdfSubject.py
+++ b/rdfalchemy/rdfSubject.py
@@ -331,7 +331,3 @@ class rdfSubject(object):
             print "%20s = %s" % (db.qname(p), str(o))
         print " "
 
-    def md5_term_hash(self):
-        """Not sure what good this method is but it's defined for
-        rdflib.Identifiers so it's here for now"""
-        return self.resUri.md5_term_hash()

--- a/rdfalchemy/rdfsSubject.py
+++ b/rdfalchemy/rdfsSubject.py
@@ -19,7 +19,10 @@ from rdfalchemy import (
     BNode,
     URIRef
 )
-from rdflib.py3compat import PY3
+try:
+    from rdflib.py3compat import PY3
+except:
+    from six import PY3
 from rdflib.term import Identifier
 from descriptors import (
     rdfSingle,
@@ -93,7 +96,7 @@ class rdfsSubject(rdfSubject, Identifier):
         # improve this do do some kind of hash with classname??
         # this uses _weakrefs to allow us to return an existing object
         # rather than copies
-        md5id = obj.md5_term_hash()
+        md5id = obj.n3()
         newobj = rdfsSubject._weakrefs.get(md5id, None)
         log.debug("looking for weakref %s found %s" % (md5id, newobj))
         if newobj:
@@ -101,7 +104,7 @@ class rdfsSubject(rdfSubject, Identifier):
         newobj = super(rdfSubject, obj).__new__(subclass, obj.resUri)
         log.debug("add a weakref %s", newobj)
         newobj._nodetype = obj._nodetype
-        rdfsSubject._weakrefs[newobj.md5_term_hash()] = newobj
+        rdfsSubject._weakrefs[newobj.n3()] = newobj
         return newobj
 
     def __init__(self, resUri=None, **kwargs):

--- a/rdfalchemy/sparql/__init__.py
+++ b/rdfalchemy/sparql/__init__.py
@@ -12,7 +12,6 @@ from rdfalchemy.sparql.parsers import (
 )
 
 from rdflib import ConjunctiveGraph
-from rdflib.py3compat import format_doctest_out
 # from rdflib.plugins.parsers.ntriples import NTriplesParser
 
 from urllib2 import urlopen, Request, HTTPError
@@ -349,17 +348,16 @@ class SPARQLGraph(object):
             raise HTTPError(e)
 
     @classmethod
-    @format_doctest_out
     def _processInitBindings(cls, query, initBindings):
         """
         _processInitBindings will convert a query by replacing the Variables
 
         >>> SPARQLGraph._processInitBindings(
         ...     'SELECT ?x { ?x ?y ?z }', {'z' : 'hi'})
-        %(u)s'SELECT ?x { ?x ?y "hi" }'
+        u'SELECT ?x { ?x ?y "hi" }'
         >>> SPARQLGraph._processInitBindings(
         ...     'SELECT ?x { ?x <http://example/?z=1> ?z }', {'z' : 'hi'})
-        %(u)s'SELECT ?x { ?x <http://example/?z=1> "hi" }'
+        u'SELECT ?x { ?x <http://example/?z=1> "hi" }'
 
         :param query: the query to process
         :param initBindings: a dict of variable to value"""

--- a/rdfalchemy/sparql/parsers.py
+++ b/rdfalchemy/sparql/parsers.py
@@ -9,7 +9,10 @@ from rdfalchemy.exceptions import (
     ParseError
 )
 
-from rdflib.py3compat import b
+try:
+    from rdflib.py3compat import b
+except:
+    from six import b
 
 try:
     import json

--- a/rdfalchemy/sparql/sesame2.py
+++ b/rdfalchemy/sparql/sesame2.py
@@ -5,7 +5,7 @@ from rdfalchemy.sparql.parsers import (
     _XMLSPARQLHandler,
     _JSONSPARQLHandler
 )
-from rdflib.plugins.serializers.nt import _xmlcharref_encode
+from rdflib.plugins.serializers.nt import _quoteLiteral
 
 from rdflib.plugins.parsers.ntriples import NTriplesParser
 
@@ -96,7 +96,7 @@ class SesameGraph(SPARQLGraph):
         if p:
             query['pred'] = p.n3()
         if o:
-            query['obj'] = _xmlcharref_encode(o.n3())
+            query['obj'] = _quoteLiteral(o.n3())
             # o.n3()
             # quote_plus(o.n3().encode("utf-8"))
         if context:


### PR DESCRIPTION
The py3compat package was removed from rdflib for 5.0. This fixes RDFAlchemy so that it works with the upcoming release, but still works with 4.2.x.